### PR TITLE
gcp: Purelymail SMTP + Wasabi S3 state backend

### DIFF
--- a/terraform/gcp/backend.tf.example
+++ b/terraform/gcp/backend.tf.example
@@ -5,14 +5,43 @@
 # versioned bucket you control — never on local disk, never committed. `backend.tf`
 # is gitignored for exactly this reason.
 #
-#   gsutil mb -l us-west1 gs://YOUR-TF-STATE-BUCKET
-#   gsutil versioning set on gs://YOUR-TF-STATE-BUCKET
-#   cp backend.tf.example backend.tf   # then edit the bucket name
-#   terraform init
+# --- Career Caddy prod uses Wasabi (S3-compatible) -------------------------
+# Bucket: career-caddy.prod.tfstate (us-east-1, versioning ON), created with:
+#   aws --profile wasabi --endpoint-url https://s3.wasabisys.com s3 mb s3://career-caddy.prod.tfstate
+#   aws --profile wasabi --endpoint-url https://s3.wasabisys.com s3api \
+#     put-bucket-versioning --bucket career-caddy.prod.tfstate \
+#     --versioning-configuration Status=Enabled
+#   cp backend.tf.example backend.tf   # then edit as below
+#   tofu init -migrate-state
+#
+# Auth: locally via the `wasabi` aws profile (below); in CI set AWS_ACCESS_KEY_ID
+# / AWS_SECRET_ACCESS_KEY env from secrets and drop the `profile` line.
 
 terraform {
-  backend "gcs" {
-    bucket = "YOUR-TF-STATE-BUCKET"
-    prefix = "career-caddy/gcp"
+  backend "s3" {
+    bucket = "career-caddy.prod.tfstate"
+    key    = "career-caddy/gcp/default.tfstate"
+    region = "us-east-1"
+
+    endpoints = { s3 = "https://s3.wasabisys.com" }
+    profile   = "wasabi" # CI: drop this, use AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+
+    use_lockfile   = true # S3-native state locking (OpenTofu >=1.10) — no DynamoDB
+    use_path_style = true # Wasabi: path-style addressing
+
+    # Non-AWS S3 endpoint: skip the AWS-specific preflight/checksum behavior.
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_s3_checksum            = true
   }
 }
+
+# --- Alternative: Google Cloud Storage -------------------------------------
+# terraform {
+#   backend "gcs" {
+#     bucket = "YOUR-TF-STATE-BUCKET"
+#     prefix = "career-caddy/gcp"
+#   }
+# }

--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -43,11 +43,20 @@ locals {
       uses_db     = true
       health_path = "/api/v1/healthcheck/"
       environment = merge(local.django_common, {
-        CORS_ALLOWED_ORIGINS      = "https://${local.hosts.app}"
-        CSRF_TRUSTED_ORIGINS      = "https://${local.hosts.app}"
-        FRONTEND_URL              = "https://${local.hosts.app}"
-        INSTANCE_ORIGIN           = "https://${local.hosts.app}"
-        EMAIL_BACKEND             = "django.core.mail.backends.console.EmailBackend"
+        CORS_ALLOWED_ORIGINS = "https://${local.hosts.app}"
+        CSRF_TRUSTED_ORIGINS = "https://${local.hosts.app}"
+        FRONTEND_URL         = "https://${local.hosts.app}"
+        INSTANCE_ORIGIN      = "https://${local.hosts.app}"
+        # Real SMTP once email_host_password is supplied; until then fall back to
+        # the console backend so a missing password can't 500 a signup.
+        EMAIL_BACKEND   = var.email_host_password != "" ? "django.core.mail.backends.smtp.EmailBackend" : "django.core.mail.backends.console.EmailBackend"
+        EMAIL_HOST      = var.email_host
+        EMAIL_PORT      = tostring(var.email_port)
+        EMAIL_HOST_USER = var.email_host_user
+        EMAIL_USE_TLS   = "True"
+        # From-address must be a real Purelymail mailbox/alias or mail is rejected;
+        # default to the authenticated user, fall back to noreply@apex if unset.
+        DEFAULT_FROM_EMAIL        = var.email_host_user != "" ? var.email_host_user : "noreply@${local.base}"
         SCRAPING_ENABLED          = "False"
         USE_MCP_BROWSER_AGENT     = "False"
         GUNICORN_HOST             = "0.0.0.0" # bind all interfaces; Cloud Run probe can't reach 127.0.0.1
@@ -56,7 +65,7 @@ locals {
         SA_SCHEMA_ON_POST_MIGRATE = "True"
         SCREENSHOT_DIR            = "/tmp/screenshots"
       })
-      secret_keys = ["SECRET_KEY", "DATABASE_URL", "OPENAI_API_KEY"]
+      secret_keys = ["SECRET_KEY", "DATABASE_URL", "OPENAI_API_KEY", "EMAIL_HOST_PASSWORD"]
     }
     events = {
       image       = local.images.api

--- a/terraform/gcp/secrets.tf
+++ b/terraform/gcp/secrets.tf
@@ -11,6 +11,7 @@ locals {
     },
     var.openai_api_key != "" ? { OPENAI_API_KEY = var.openai_api_key } : {},
     var.anthropic_api_key != "" ? { ANTHROPIC_API_KEY = var.anthropic_api_key } : {},
+    var.email_host_password != "" ? { EMAIL_HOST_PASSWORD = var.email_host_password } : {},
   )
 }
 
@@ -29,8 +30,8 @@ resource "google_secret_manager_secret" "app" {
 }
 
 resource "google_secret_manager_secret_version" "app" {
-  for_each       = nonsensitive(toset(keys(local.secret_values)))
-  secret           = google_secret_manager_secret.app[each.key].id
+  for_each    = nonsensitive(toset(keys(local.secret_values)))
+  secret      = google_secret_manager_secret.app[each.key].id
   secret_data = local.secret_values[each.key]
 }
 

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -29,3 +29,10 @@ image_tag = "latest"
 # Optional AI keys. Left empty, the chat service starts but won't answer.
 # openai_api_key    = "sk-..."
 # anthropic_api_key = "sk-ant-..."
+
+# Outbound email (SMTP). Without email_host_password the api uses Django's
+# console backend and NO mail is sent (signup/welcome + admin-notify silently
+# no-op). Set the password (→ Secret Manager) to switch to real SMTP. Defaults:
+# email_host = "smtp.purelymail.com", email_port = 587, EMAIL_USE_TLS = True.
+# email_host_user     = "noreply@yourdomain"
+# email_host_password = "..."

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -58,3 +58,32 @@ variable "anthropic_api_key" {
   default     = ""
   sensitive   = true
 }
+
+# Outbound email (SMTP). When email_host_password is set, the api service
+# switches from the console backend to real SMTP so signup/welcome + admin-notify
+# mail actually sends. host/port/user are plain env; the password lands in Secret
+# Manager (see secrets.tf). Defaults target Purelymail.
+variable "email_host" {
+  description = "SMTP host for outbound mail (e.g. Purelymail: smtp.purelymail.com)."
+  type        = string
+  default     = "smtp.purelymail.com"
+}
+
+variable "email_port" {
+  description = "SMTP port (587 = STARTTLS/TLS, 465 = implicit SSL)."
+  type        = number
+  default     = 587
+}
+
+variable "email_host_user" {
+  description = "SMTP auth user — the sending mailbox (e.g. noreply@yourdomain)."
+  type        = string
+  default     = ""
+}
+
+variable "email_host_password" {
+  description = "SMTP mailbox/app password. Empty = console backend (no real send)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## What

Wires the GCP prod terraform for real outbound email and moves the state-backend reference to Wasabi (S3-compatible).

### Email (fixes the "new signup got no email" bug)
Prod on GCP was running Django's **console** email backend — mail was printed to Cloud Run logs and never sent. The Purelymail SMTP config that the old racknerd prod used never got ported into the GCP terraform.

- `EMAIL_BACKEND` auto-switches to real SMTP once `email_host_password` is set; otherwise it stays on the console backend so a missing secret can't 500 a signup.
- Adds `EMAIL_HOST` / `EMAIL_PORT` / `EMAIL_HOST_USER` / `EMAIL_USE_TLS` env + `EMAIL_HOST_PASSWORD` into Secret Manager (same conditional pattern as `OPENAI_API_KEY`).
- `DEFAULT_FROM_EMAIL` defaults to the authenticated mailbox (`email_host_user`) rather than a hardcoded `noreply@` — Purelymail rejects a from-address that isn't a real mailbox.

### State backend → Wasabi
- `backend.tf.example` rewritten to a Wasabi S3 stanza: custom `endpoints.s3`, path-style addressing, `use_lockfile` (S3-native locking, no DynamoDB), and `skip_*` flags for the non-AWS preflight/checksum. GCS kept as a commented alternative for other self-hosters.

## Operator follow-up (not in this PR)
- Real `email_host_user` / `email_host_password` go into a gitignored `terraform.tfvars` (they live in `career_caddy/.env` today).
- State bucket `career-caddy.prod.tfstate` is already created on Wasabi (versioning on); `tofu init -migrate-state` is a separate gated step.

Part of epic CC-178 (deploy submodule + GCP CI/CD inversion); this is CC-180 step 1.
