### PR TITLE
feat(gcp): always-on qcluster worker to drain django_q_ormq (CC-199) [PROPOSAL]

### DIFF
--- a/terraform/gcp/worker.tf
+++ b/terraform/gcp/worker.tf
@@ -1,0 +1,140 @@
+# Async worker (CC-190) — the django-q2 ``qcluster`` drainer that was DROPPED in
+# the 2026-07-14 GCP cutover. AWS (terraform/aws locals.tf `worker`) + the
+# generic reference both run a `manage.py qcluster` daemon; GCP shipped without
+# one, so EVERY raw django-q2 async_task() call site has been stranded since the
+# cutover: parse_scrape_job (extension Sends via /scrapes/from-text/), score_job,
+# summaries, resume ingest, JA-match, questions, reextract, federation. Their
+# OrmQ rows pile up on django_q_ormq with nothing to drain them.
+#
+# CC-169 (tasks.tf) only moved the ONE push-shaped path (cover-letter) onto Cloud
+# Tasks. Everything else still enqueues via django-q2 async_task and needs a
+# resident qcluster to execute. This service restores that drainer.
+#
+# ── WHY A min-instances=1 SERVICE, NOT A CLOUD RUN JOB / GCE ──────────────────
+# qcluster is a CONTINUOUS PULL-LOOP daemon: it polls django_q_ormq forever, it
+# is not a request handler and not a batch that exits. That rules out:
+#   • A plain (request-billed) Cloud Run service — it scales to zero between
+#     requests, and nothing sends it requests, so the loop never runs.
+#   • A Cloud Run Job — Jobs run a task to COMPLETION; qcluster never completes.
+#     A Scheduler-driven bounded sweep would need an app-side run-once mode
+#     django-q2 doesn't cleanly provide, and re-introduces sweep latency.
+#   • A Compute Engine container VM — works, but bolts a hand-managed VM (patching,
+#     COS, no revision rollout) onto an otherwise all-serverless stack. Rejected
+#     unless Doug wants to avoid the shim below.
+# A Cloud Run SERVICE with min_instance_count=1 + CPU ALWAYS-ALLOCATED keeps one
+# instance resident 24/7 with background CPU, so the qcluster loop runs like the
+# Fargate `worker`. Same image, same DB, same secrets/env as `api`.
+#
+# ── THE ONE APP DEPENDENCY (Doug / cc-api gate) ──────────────────────────────
+# Cloud Run REQUIRES the container to answer a startup probe on $PORT. qcluster
+# opens NO socket (api/scripts/entrypoint.sh only migrates + runs gunicorn; there
+# is no qcluster mode and no health-port shim in the api image). So this service
+# as written WILL FAIL its startup probe until the api image ships a tiny
+# health-port shim: a command that backgrounds `manage.py qcluster` and serves a
+# 200 on $PORT (e.g. a `qcluster-web` entrypoint, ~15 lines). That is a cc-api
+# change, filed as the app half of CC-190. The `command` + `startup_probe` below
+# are written against that shim's contract; adjust the command to match whatever
+# cc-api names it.
+
+resource "google_cloud_run_v2_service" "worker" {
+  name                = "worker"
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL" # reachable, but no public invoker binding (see below)
+  deletion_protection = var.deletion_protection
+
+  template {
+    service_account = google_service_account.run.email
+
+    # Resident: exactly one always-on instance runs the pull loop. No autoscaling
+    # past 1 — django-q2 Q_WORKERS handles intra-instance concurrency, and a
+    # second instance would just double-poll the same OrmQ table.
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.main.connection_name]
+      }
+    }
+
+    containers {
+      image = local.images.api
+
+      # Health-port shim (CC-190 app half): background qcluster, serve 200 on $PORT.
+      # Placeholder name — align with the cc-api entrypoint once it lands.
+      command = ["/app/scripts/qcluster-web.sh"]
+
+      ports {
+        container_port = 8000
+      }
+
+      resources {
+        # CPU ALWAYS allocated — the daemon must keep running BETWEEN requests
+        # (there are none). Without this, Cloud Run throttles CPU to ~0 off-request
+        # and the pull loop stalls. This is the load-bearing setting for a daemon.
+        cpu_idle          = false
+        startup_cpu_boost = true
+        limits            = { cpu = "1", memory = "1Gi" }
+      }
+
+      # qcluster does its own migrate-independence; api owns migrations, so this
+      # worker must NOT run them. Mirror the `tasks` service env, minus Cloud Tasks.
+      dynamic "env" {
+        for_each = merge(local.django_common, {
+          GUNICORN_HOST             = "0.0.0.0"
+          SA_SCHEMA_ON_POST_MIGRATE = "False"
+          SCRAPING_ENABLED          = "False"
+          USE_MCP_BROWSER_AGENT     = "False"
+          EMAIL_BACKEND             = "django.core.mail.backends.console.EmailBackend"
+          SCREENSHOT_DIR            = "/tmp/screenshots"
+          Q_WORKERS                 = "2"
+        })
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = { for k in ["SECRET_KEY", "DATABASE_URL", "OPENAI_API_KEY"] : k => k if contains(keys(local.secret_ids), k) }
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = local.secret_ids[env.key]
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+
+      # The shim serves a plain 200 on $PORT; the probe just proves the process is
+      # up (and thus the backgrounded qcluster loop started). Generous failure
+      # budget so a slow first migrate-check / import doesn't kill the revision.
+      startup_probe {
+        http_get {
+          path = "/healthz"
+        }
+        initial_delay_seconds = 10
+        period_seconds        = 10
+        timeout_seconds       = 5
+        failure_threshold     = 6
+      }
+    }
+  }
+
+  depends_on = [google_project_service.apis, google_secret_manager_secret_version.app]
+}
+
+# NO public invoker IAM binding: this service takes no external traffic. Cloud Run
+# still keeps the min-1 instance warm regardless of invoker bindings, and the
+# startup probe is internal — so leaving allUsers OFF is correct (unlike the
+# lb_services, which need allUsers to be reachable through the LB).


### PR DESCRIPTION
## CC-199 — restore the async worker GCP dropped in the 2026-07-14 cutover

**PROPOSAL — do not self-merge. Prod terraform is Doug-applied.** Exact `tofu` steps below.

### The gap

The AWS + generic reference deploys run a `manage.py qcluster` daemon (`terraform/aws/locals.tf:86` + `terraform/generic/main.tf`, role `django-q2-qcluster`). **The GCP cutover shipped without one.** `terraform/gcp/` has api/events/frontend/mcp (`locals.tf` `lb_services`) + chat + a `tasks` service (`tasks.tf` — runs *gunicorn* as the CC-169 Cloud Tasks handler, **not** qcluster). Nothing drains `django_q_ormq`.

So since 2026-07-14 **every raw `async_task()` enqueues an OrmQ row nothing executes** — `parse_scrape_job` (extension Sends via `/scrapes/from-text/`), `score_job`, summaries, resume ingest, JA-match, questions, reextract, federation. Only CC-169 cover-letter (Cloud Tasks → `/tasks/cover-letter/`) has a GCP executor. This is the infra root cause behind the 2026-07-17 CC-122 recurrence.

### The change — `terraform/gcp/worker.tf`

A **min-instances=1 Cloud Run service** `worker` running qcluster off the same api image / Cloud SQL / secrets / env as `api`, with **CPU always-allocated** (`cpu_idle = false`).

### Why this shape (not a Job, not GCE)

`qcluster` is a **continuous pull-loop daemon** — it polls `django_q_ormq` forever; it is not a request handler and not a batch that exits.

| Option | Verdict |
|---|---|
| Plain (request-billed) Cloud Run service | ❌ scales to zero; nothing sends it requests → loop never runs |
| Cloud Run **Job** | ❌ Jobs run to *completion*; qcluster never completes. A Scheduler-driven bounded sweep needs a run-once mode django-q2 doesn't cleanly provide + re-adds sweep latency |
| Compute Engine container VM | ❌ works, but bolts a hand-patched VM onto an all-serverless stack (no revision rollout) |
| **Cloud Run service, min-instances=1, CPU always-allocated** | ✅ one resident instance with background CPU runs the loop 24/7, like the Fargate `worker` |

`cpu_idle = false` is the load-bearing setting: without it Cloud Run throttles CPU to ~0 between requests (there are none) and the loop stalls.

### One dependency — a cc-api health-port shim (Doug / cc-api gate)

Cloud Run **requires** the container to answer a startup probe on `$PORT`. `qcluster` opens no socket, and `api/scripts/entrypoint.sh` has no qcluster mode or health-port shim. **As written this service will fail its startup probe until the api image ships a ~15-line shim** that backgrounds `manage.py qcluster` and serves a 200 on `$PORT` (e.g. `scripts/qcluster-web.sh` → `/healthz`). The `command` + `startup_probe` here are written against that shim's contract — adjust the command to match whatever cc-api names it. **File the app half as a cc-api sub-item of CC-199 before applying.**

### Already resolved (no change needed)

CC-122's RCA flagged `CC_TASKS_ENABLED` as set only on the `tasks` service — it is now also on `api` (`run.tf:59`). No fix required here.

### Doug applies (from `career_caddy_deploy/terraform/gcp`, Wasabi backend)

```
tofu init            # if the Wasabi S3 backend isn't initialized in this checkout
tofu plan            # expect: 1 to add — google_cloud_run_v2_service.worker
tofu apply           # after the cc-api health-port shim image is published
```

Expected plan: **1 to add** (`google_cloud_run_v2_service.worker`), 0 change, 0 destroy. `tofu validate` passes locally.

### Post-apply follow-up

Once the worker drains, reclaim the 4 stuck LinkedIn extension scrapes: `QAPRUZw2sK`, `g8US6ZCwbt`, `sWYYGxdRfW`, `mvGREbup5Q` (all `linkedin.com/jobs/view/4437716572/`).

Closes the infra half of CC-199. Related: CC-122 (extension bug this unblocks), CC-169 (Cloud Tasks cover-letter dispatch).
