### PR TITLE
fix(gcp): resolve :latest to a digest so tofu apply actually rolls

### DIFF
--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -11,12 +11,15 @@ locals {
   }
 
   # Artifact Registry image URIs. Cloud Run cannot pull ghcr.io directly, so the
-  # public GHCR images must be MIRRORED into this AR repo first (see README).
+  # public GHCR images are MIRRORED into this AR repo first (see README).
   ar_host = "${var.ar_region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.main.repository_id}"
+  # Deploy DIGEST-pinned refs resolved from each image's :${var.image_tag} at plan
+  # time (data sources in registry.tf), so pushing a new :latest + `tofu apply`
+  # actually rolls a new revision. ar_host retained for reference/other consumers.
   images = {
-    api      = "${local.ar_host}/career_caddy_api:${var.image_tag}"
-    frontend = "${local.ar_host}/career_caddy_frontend:${var.image_tag}"
-    ai       = "${local.ar_host}/career_caddy_ai:${var.image_tag}"
+    api      = data.google_artifact_registry_docker_image.api.self_link
+    frontend = data.google_artifact_registry_docker_image.frontend.self_link
+    ai       = data.google_artifact_registry_docker_image.ai.self_link
   }
 
   # api is reached internally via the single LB host (static string → no

--- a/terraform/gcp/registry.tf
+++ b/terraform/gcp/registry.tf
@@ -10,3 +10,30 @@ resource "google_artifact_registry_repository" "main" {
 
   depends_on = [google_project_service.apis]
 }
+
+# Resolve each service image's tag (var.image_tag, default "latest") to its
+# immutable DIGEST at plan time. local.images deploys the digest-pinned ref, which
+# is what makes the plain "docker push :latest + tofu apply" workflow actually
+# ROLL a new revision: moving the :latest tag changes the resolved digest -> the
+# Cloud Run service spec changes -> a new revision deploys. When :latest has NOT
+# moved, the digest is identical -> no diff, no needless roll. Keeps the :latest
+# workflow; no per-deploy SHA tags. (A Cloud Run revision is otherwise pinned to
+# the digest captured when it was created, so re-pushing the same :latest tag
+# alone never redeploys — the spec string is unchanged.)
+data "google_artifact_registry_docker_image" "api" {
+  location      = var.ar_region
+  repository_id = google_artifact_registry_repository.main.repository_id
+  image_name    = "career_caddy_api:${var.image_tag}"
+}
+
+data "google_artifact_registry_docker_image" "frontend" {
+  location      = var.ar_region
+  repository_id = google_artifact_registry_repository.main.repository_id
+  image_name    = "career_caddy_frontend:${var.image_tag}"
+}
+
+data "google_artifact_registry_docker_image" "ai" {
+  location      = var.ar_region
+  repository_id = google_artifact_registry_repository.main.repository_id
+  image_name    = "career_caddy_ai:${var.image_tag}"
+}


### PR DESCRIPTION
## Problem

Pushing a new image to `:latest` + `tofu apply` does **not** redeploy. Cloud Run pins a revision to the image **digest** at creation; the module's spec is `career_caddy_*:latest` (a tag string), so moving `:latest` in AR leaves the spec unchanged → `tofu plan` shows no diff → no new revision → the old digest keeps running. Caught live: after pushing the api chat/tasks image to `:latest`, `api` stayed on the old digest (`api-00005-75d`, `sha256:265fd0…`).

## Fix

Resolve each image's `:${var.image_tag}` (default `latest`) to its immutable digest at plan time via `data "google_artifact_registry_docker_image"` (api / frontend / ai), and point `local.images` at the resolved `self_link` (digest-pinned).

Result:
- `docker push …:latest` + `tofu apply` → the resolved digest changes → the service spec changes → **a new revision rolls**.
- If `:latest` hasn't moved → same digest → no diff, no needless roll.
- Live revisions are digest-pinned, so you can see exactly which image is running.

No per-deploy SHA tags; the `:latest` workflow is unchanged. `tofu validate` ✅.

## Deploy note

Applying this **is** the pending deploy: it resolves the current `:latest` for **api** (`4d24d16` — CC-212 chat + CC-214 tasks) and **frontend** (`5876121` — CC-217 score fix) and rolls them; ai/mcp/chat re-resolve to their unchanged image (no-op). Prod-infra terraform is Doug-applied.
