### PR TITLE
feat(gcp): Cloud Scheduler recurring sweeps → /tasks/run-scheduled/ (CC-213)

### DIFF
--- a/terraform/gcp/scheduler.tf
+++ b/terraform/gcp/scheduler.tf
@@ -1,0 +1,82 @@
+# Cloud Scheduler recurring sweeps (CC-213) — replaces the django-q2 `Schedule`
+# cron rows the qcluster worker used to own. Cloud Tasks is a queue, not a cron,
+# and GCP has no Job runner, so the recurring clock is Cloud Scheduler: each job
+# fires on its cron and OIDC-POSTs {"name": "<sweep>"} to the IAM-private `tasks`
+# Cloud Run service's /tasks/run-scheduled/ handler, reusing the same
+# tasks-invoker SA + service audience already wired in tasks.tf.
+#
+# CONTRACT with the api handler (job_hunting.lib.schedule_kinds.SCHEDULE_REGISTRY
+# + tasks_handlers.run_scheduled_task_handler) — these MUST match exactly:
+#   - path:  /tasks/run-scheduled/
+#   - body:  {"name": "<sweep-name>"}
+#   - names: the keys below == SCHEDULE_REGISTRY's keys.
+#
+# Sweeps are read/idempotent → at-least-once is safe. This fires ALONGSIDE the
+# still-running CC-199 qcluster worker's Schedules until the CC-208 teardown;
+# the transient double-fire is harmless (idempotent).
+
+resource "google_project_service" "cloudscheduler" {
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+# name -> cron. Crons mirror the django-q2 Schedule intervals (migration in the
+# comment) and the SCHEDULE_REGISTRY interval_seconds on the api side:
+#   sweep_stale_scrape_claims    0086  every 5 min
+#   federation_dispatch_sweep    0090  every 1 min
+#   prune_scrape_html            0109  hourly
+#   sweep_stale_unclaimed_holds  0113  every 5 min
+locals {
+  scheduled_sweeps = {
+    sweep_stale_scrape_claims   = "*/5 * * * *"
+    federation_dispatch_sweep   = "* * * * *"
+    prune_scrape_html           = "0 * * * *"
+    sweep_stale_unclaimed_holds = "*/5 * * * *"
+  }
+
+  # The /tasks/run-scheduled/ endpoint on the IAM-private tasks service. The
+  # OIDC audience for Cloud Run is the bare service URL (no path).
+  run_scheduled_url = "${google_cloud_run_v2_service.tasks.uri}/tasks/run-scheduled/"
+}
+
+resource "google_cloud_scheduler_job" "sweep" {
+  for_each = local.scheduled_sweeps
+
+  name      = "${local.name}-sweep-${replace(each.key, "_", "-")}"
+  region    = var.region
+  schedule  = each.value
+  time_zone = "Etc/UTC"
+
+  # A sweep that overruns its interval must not stack: the handler is
+  # idempotent, and Cloud Scheduler retries a failed fire on its own backoff.
+  attempt_deadline = "320s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = local.run_scheduled_url
+    headers     = { "Content-Type" = "application/json" }
+    body        = base64encode(jsonencode({ name = each.key }))
+
+    # Same identity Cloud Tasks uses (tasks.tf) — already granted run.invoker on
+    # the tasks service. The audience is the bare Cloud Run service URL.
+    oidc_token {
+      service_account_email = google_service_account.tasks_invoker.email
+      audience              = google_cloud_run_v2_service.tasks.uri
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+    google_cloud_run_v2_service_iam_member.tasks_invoker,
+  ]
+}
+
+# --- outputs ----------------------------------------------------------------
+output "scheduled_sweep_jobs" {
+  description = "Cloud Scheduler job names driving the recurring sweeps (CC-213)."
+  value       = [for j in google_cloud_scheduler_job.sweep : j.name]
+}


### PR DESCRIPTION
## What (PR 2 of 2 — terraform, Doug-APPLIED / propose only)

Adds `deploy/terraform/gcp/scheduler.tf`: the GCP recurring clock for the sweeps that used to run as django-q2 `Schedule` rows on the qcluster worker. Cloud Tasks is a queue not a cron and GCP has no `Job` runner, so Cloud Scheduler fires each sweep on its cron and OIDC-POSTs `{"name": "<sweep>"}` to the IAM-private `tasks` Cloud Run service's **`/tasks/run-scheduled/`** handler.

**Do NOT apply here — Doug applies the terraform.** The paired app PR (career_caddy_api **#237**) is review-only.

### What it creates
- Enables `cloudscheduler.googleapis.com` (standalone `google_project_service`, same pattern `tasks.tf` used for `cloudtasks`).
- One `google_cloud_scheduler_job` per sweep via `for_each` over a `name → cron` map.
- **Reuses** the existing `tasks_invoker` SA (already granted `run.invoker` on the tasks service) + the tasks service URI as the OIDC audience — **no new IAM, no new SA**.

### Per-sweep cadence table (crons mirror the django-q2 Schedule intervals + the api SCHEDULE_REGISTRY)
| Sweep name | Migration | Cron | interval_seconds (api) |
|---|---|---|---|
| `sweep_stale_scrape_claims` | 0086 | `*/5 * * * *` | 300 |
| `federation_dispatch_sweep` | 0090 | `* * * * *` | 60 |
| `prune_scrape_html` | 0109 | `0 * * * *` | 3600 |
| `sweep_stale_unclaimed_holds` | 0113 | `*/5 * * * *` | 300 |

(The 0111 `sweep_orphaned_attended_holds` Schedule is intentionally omitted — its worker fn was never implemented; see api PR #237 for the finding.)

### Validation
- `tofu validate`: **Success** (all cross-references — `google_cloud_run_v2_service.tasks`, `google_service_account.tasks_invoker`, `local.name`, `var.region` — resolve).
- `tofu fmt`: clean; **only `scheduler.tf` touched** (no fmt-churn on unrelated files).

## The shared contract (with the api PR #237)
`scheduler.tf` and the api handler/registry MUST agree on all three:
- **handler path:** `/tasks/run-scheduled/`
- **request body:** `{"name": "<sweep-name>"}` (base64-encoded JSON, per Cloud Scheduler's `body` field)
- **sweep-name keys:** exactly the api `SCHEDULE_REGISTRY` keys (the 4 rows above)

## Additive — strands nothing
Fires alongside the still-running CC-199 qcluster worker's `Schedule` rows until the CC-208 teardown; the transient double-fire is harmless because every sweep is idempotent. Once CC-208 removes the worker, Cloud Scheduler is the sole driver on GCP.