### PR TITLE
feat(gcp): wire Wasabi resume-blob storage into api + tasks (CC-204)

### DIFF
--- a/terraform/gcp/locals.tf
+++ b/terraform/gcp/locals.tf
@@ -67,8 +67,15 @@ locals {
         GUNICORN_THREADS          = "4"
         SA_SCHEMA_ON_POST_MIGRATE = "True"
         SCREENSHOT_DIR            = "/tmp/screenshots"
-      })
-      secret_keys = ["SECRET_KEY", "DATABASE_URL", "OPENAI_API_KEY", "EMAIL_HOST_PASSWORD"]
+        },
+        # CC-204 Wasabi bucket env (empty map when the feature is off → api falls
+        # back to local FileSystemStorage). The creds are secrets, wired
+        # separately in run.tf; these are the plain bucket/endpoint/region vars.
+      local.wasabi_env)
+      secret_keys = concat(
+        ["SECRET_KEY", "DATABASE_URL", "OPENAI_API_KEY", "EMAIL_HOST_PASSWORD"],
+        local.wasabi_secret_keys, # CC-204: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      )
     }
     events = {
       image       = local.images.api

--- a/terraform/gcp/run.tf
+++ b/terraform/gcp/run.tf
@@ -6,11 +6,11 @@
 resource "google_cloud_run_v2_service" "lb" {
   for_each = local.lb_services
 
-  name     = each.key
-  location = var.region
-  ingress  = "INGRESS_TRAFFIC_ALL"
+  name                = each.key
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
   deletion_protection = var.deletion_protection
-  
+
   template {
     service_account = google_service_account.run.email
 
@@ -83,6 +83,22 @@ resource "google_cloud_run_v2_service" "lb" {
         }
       }
 
+      # CC-204 Wasabi creds (api only) — separate map from local.secret_ids.
+      # Empty when the feature is off. Only api writes the upload, so only api
+      # gets these here; the tasks service wires them in tasks.tf.
+      dynamic "env" {
+        for_each = each.key == "api" ? local.wasabi_secret_ids : {}
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = env.value
+              version = "latest"
+            }
+          }
+        }
+      }
+
       dynamic "volume_mounts" {
         for_each = each.value.uses_db ? [1] : []
         content {
@@ -99,9 +115,9 @@ resource "google_cloud_run_v2_service" "lb" {
 # --- chat: internal LLM service, invoked by api via IAM (no LB) --------------
 
 resource "google_cloud_run_v2_service" "chat" {
-  name     = "chat"
-  location = var.region
-  ingress  = "INGRESS_TRAFFIC_ALL" # reachable, but IAM allows only the runtime SA
+  name                = "chat"
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"   # reachable, but IAM allows only the runtime SA
   deletion_protection = var.deletion_protection # stateless POC service — allow teardown
 
   template {
@@ -141,7 +157,7 @@ resource "google_cloud_run_v2_service" "chat" {
         value = "openai:gpt-4o-mini"
       }
 
-      
+
       dynamic "env" {
         for_each = { for k in ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] : k => k if contains(keys(local.secret_ids), k) }
         content {
@@ -157,7 +173,7 @@ resource "google_cloud_run_v2_service" "chat" {
     }
   }
 
-  
+
   depends_on = [google_project_service.apis, google_secret_manager_secret_version.app]
 }
 

--- a/terraform/gcp/storage.tf
+++ b/terraform/gcp/storage.tf
@@ -1,0 +1,105 @@
+# Wasabi (S3-compatible) blob storage for uploaded resumes — CC-204.
+#
+# The api service persists the uploaded resume to default_storage (Resume.file)
+# and enqueues only the resume_id; the tasks service's resume_parse_job worker
+# reads the blob back from the SAME bucket. So BOTH services need the Wasabi
+# creds + endpoint/region/bucket env. Wasabi is out-of-band (not a GCP
+# resource) — this file only wires the credentials/env into Cloud Run; Doug
+# provisions the bucket + access key (see the PR checklist).
+#
+# Reuses Doug's existing Wasabi conventions (the wasabi backup scripts + the
+# tofu remote-state backend): endpoint https://s3.us-west-1.wasabisys.com,
+# region us-west-1, path-style addressing. Co-located with the us-west1 GCP
+# compute.
+#
+# ENV-VAR CONTRACT (must match the api settings.py STORAGES block exactly):
+#   AWS_STORAGE_BUCKET_NAME  — plain env; presence flips api settings to S3
+#   AWS_S3_ENDPOINT_URL      — plain env
+#   AWS_S3_REGION_NAME       — plain env
+#   AWS_ACCESS_KEY_ID        — Secret Manager
+#   AWS_SECRET_ACCESS_KEY    — Secret Manager
+
+variable "wasabi_bucket" {
+  description = "Wasabi bucket for uploaded resumes (CC-204). Empty = feature off (api falls back to local FileSystemStorage)."
+  type        = string
+  default     = ""
+}
+
+variable "wasabi_endpoint_url" {
+  description = "Wasabi S3 endpoint. Region-specific host; us-west-1 co-locates with the GCP compute."
+  type        = string
+  default     = "https://s3.us-west-1.wasabisys.com"
+}
+
+variable "wasabi_region" {
+  description = "Wasabi region (matches the endpoint host)."
+  type        = string
+  default     = "us-west-1"
+}
+
+variable "wasabi_access_key_id" {
+  description = "Wasabi access key id scoped to the resume bucket. Lands in Secret Manager."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "wasabi_secret_access_key" {
+  description = "Wasabi secret access key. Lands in Secret Manager."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+locals {
+  # Feature is on only when a bucket + both creds are supplied.
+  wasabi_enabled = var.wasabi_bucket != "" && var.wasabi_access_key_id != "" && var.wasabi_secret_access_key != ""
+
+  # Wasabi creds → Secret Manager (same shape as secrets.tf's app secrets).
+  wasabi_secret_values = local.wasabi_enabled ? {
+    AWS_ACCESS_KEY_ID     = var.wasabi_access_key_id
+    AWS_SECRET_ACCESS_KEY = var.wasabi_secret_access_key
+  } : {}
+
+  # Plain (non-secret) env both api + tasks need to point at the bucket.
+  wasabi_env = local.wasabi_enabled ? {
+    AWS_STORAGE_BUCKET_NAME = var.wasabi_bucket
+    AWS_S3_ENDPOINT_URL     = var.wasabi_endpoint_url
+    AWS_S3_REGION_NAME      = var.wasabi_region
+  } : {}
+
+  # Secret keys both services reference via value_source.secret_key_ref.
+  wasabi_secret_keys = keys(local.wasabi_secret_values)
+}
+
+resource "google_secret_manager_secret" "wasabi" {
+  for_each  = nonsensitive(toset(keys(local.wasabi_secret_values)))
+  secret_id = "${local.name}-${lower(each.key)}"
+  labels    = local.common_labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_version" "wasabi" {
+  for_each    = nonsensitive(toset(keys(local.wasabi_secret_values)))
+  secret      = google_secret_manager_secret.wasabi[each.key].id
+  secret_data = local.wasabi_secret_values[each.key]
+}
+
+# key -> secret id, for Cloud Run env value_source (parallels local.secret_ids).
+locals {
+  wasabi_secret_ids = { for k, s in google_secret_manager_secret.wasabi : k => s.secret_id }
+}
+
+# Grant the runtime SA (used by BOTH the api and tasks services) read access to
+# the Wasabi creds. Mirrors iam.tf's run_access grant for the app secrets.
+resource "google_secret_manager_secret_iam_member" "wasabi_run_access" {
+  for_each  = google_secret_manager_secret.wasabi
+  secret_id = each.value.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run.email}"
+}

--- a/terraform/gcp/tasks.tf
+++ b/terraform/gcp/tasks.tf
@@ -75,6 +75,9 @@ resource "google_cloud_run_v2_service" "tasks" {
       }
 
       dynamic "env" {
+        # CC-204: the tasks service's resume_parse_job worker READS the uploaded
+        # blob from the same Wasabi bucket, so it needs the plain bucket env too
+        # (local.wasabi_env is empty when the feature is off).
         for_each = merge(local.django_common, {
           GUNICORN_HOST             = "0.0.0.0"
           SA_SCHEMA_ON_POST_MIGRATE = "False"
@@ -83,7 +86,7 @@ resource "google_cloud_run_v2_service" "tasks" {
           EMAIL_BACKEND             = "django.core.mail.backends.console.EmailBackend"
           SCREENSHOT_DIR            = "/tmp/screenshots"
           CC_TASKS_ENABLED          = "True"
-        })
+        }, local.wasabi_env)
         content {
           name  = env.key
           value = env.value
@@ -97,6 +100,20 @@ resource "google_cloud_run_v2_service" "tasks" {
           value_source {
             secret_key_ref {
               secret  = local.secret_ids[env.key]
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      # CC-204 Wasabi creds for the resume-parse worker (empty when off).
+      dynamic "env" {
+        for_each = local.wasabi_secret_ids
+        content {
+          name = env.key
+          value_source {
+            secret_key_ref {
+              secret  = env.value
               version = "latest"
             }
           }


### PR DESCRIPTION
## What (PR 2 of 2 — terraform, Doug-APPLIED / propose only)

Wires the Wasabi (S3-compatible) credentials + bucket env into **both** Cloud Run services so the CC-204 resume blob store works on GCP: the **api** service writes the uploaded resume to the bucket (via `Resume.file` / `default_storage`), and the **tasks** service's `resume_parse_job` worker reads it back.

**Do NOT apply — Doug provisions the Wasabi bucket + keys and applies.** The paired app PR (career_caddy_api **#239**) is review-only.

### What it wires
- **`storage.tf` (new):** Wasabi variables (bucket, endpoint, region, access key, secret key — endpoint/region default to the `us-west-1` wasabi convention); the two creds → Secret Manager (parallels `secrets.tf`'s app-secret shape) + the run-SA `secretAccessor` grant (parallels `iam.tf`). **Feature-gated** on `local.wasabi_enabled` (bucket + both creds present) → empty maps when off, so a plan with no Wasabi vars is a **no-op** and api falls back to local FS.
- **`locals.tf`:** merge `local.wasabi_env` (plain bucket/endpoint/region) into the api service `environment` + `concat` `wasabi_secret_keys` into its `secret_keys`.
- **`run.tf`:** api-only dynamic env block resolving the Wasabi creds from `local.wasabi_secret_ids` (separate map from `local.secret_ids`).
- **`tasks.tf`:** same `wasabi_env` + creds on the tasks service (the worker reads the blob).

**No GCP bucket resource** — Wasabi is out-of-band. This PR only creates the Secret Manager secrets + Cloud Run env/credential wiring.

## Doug must provision (before `tofu apply`)
1. **Create a Wasabi bucket** for uploaded resumes (e.g. `career-caddy-resumes`) in the **us-west-1** region (co-located with compute; matches the existing wasabi backup convention). Keep it **private** (default).
2. **Create a Wasabi access key/secret** scoped to that bucket (a dedicated sub-user is ideal — least privilege: `s3:GetObject`/`PutObject`/`DeleteObject` on the bucket).
3. **Supply the tfvars** (do NOT commit the creds):
   - `wasabi_bucket = "career-caddy-resumes"`
   - `wasabi_access_key_id = "<key>"` (sensitive)
   - `wasabi_secret_access_key = "<secret>"` (sensitive)
   - `wasabi_endpoint_url` / `wasabi_region` — only if not the `us-west-1` defaults.
4. **Optional:** a Wasabi bucket lifecycle rule to age-out orphaned objects (nice-to-have, not required).

If the vars are left empty, the whole feature is off (no secrets created, api uses local FileSystemStorage) — safe to apply as a no-op.

## Validation
- `tofu validate`: **Success** (all cross-refs — `google_service_account.run`, `local.secret_ids`, the new locals — resolve).
- `tofu fmt`: clean on all four touched files. (`sql.tf` shows pre-existing fmt drift — **left untouched**, not mine.)

## ENV-VAR CONTRACT (matches api PR #239 `settings.py` STORAGES block exactly)
| Var | Kind |
|---|---|
| `AWS_STORAGE_BUCKET_NAME` | plain env |
| `AWS_S3_ENDPOINT_URL` | plain env |
| `AWS_S3_REGION_NAME` | plain env |
| `AWS_ACCESS_KEY_ID` | Secret Manager |
| `AWS_SECRET_ACCESS_KEY` | Secret Manager |

Wired into **both** the `api` (writer) and `tasks` (reader) services.